### PR TITLE
Rename YARPP to JARPP

### DIFF
--- a/classes/JARPP_Admin.php
+++ b/classes/JARPP_Admin.php
@@ -1,6 +1,6 @@
 <?php
 
-class YARPP_Admin {
+class JARPP_Admin {
 	public $core;
 	public $hook;
 	

--- a/classes/JARPP_Cache.php
+++ b/classes/JARPP_Cache.php
@@ -1,6 +1,6 @@
 <?php
 
-abstract class YARPP_Cache {
+abstract class JARPP_Cache {
 
 	protected $core;
     protected $yarpp_time   = false;
@@ -439,7 +439,7 @@ abstract class YARPP_Cache {
 		return !in_array( $filter, $blacklist );
 	}
 	
-	/* FYI, apply_filters_if_white was used here to avoid a loop in apply_filters('the_content') > YARPP::the_content() > YARPP::related() > YARPP_Cache::body_keywords() > apply_filters('the_content').*/
+	/* FYI, apply_filters_if_white was used here to avoid a loop in apply_filters('the_content') > YARPP::the_content() > YARPP::related() > JARPP_Cache::body_keywords() > apply_filters('the_content').*/
 	function apply_filters_if_white($tag, $value) {
 		global $wp_filter, $merged_filters, $wp_current_filter;
 	

--- a/classes/JARPP_Cache_Bypass.php
+++ b/classes/JARPP_Cache_Bypass.php
@@ -1,6 +1,6 @@
 <?php
 
-class YARPP_Cache_Bypass extends YARPP_Cache {
+class JARPP_Cache_Bypass extends JARPP_Cache {
 
     public $name                = "bypass";
     public $demo_time           = false;
@@ -201,7 +201,7 @@ class YARPP_Cache_Bypass extends YARPP_Cache {
 
         // reverse lookup
         if ( is_int($related_ID) && is_null($reference_ID) ) {
-            _doing_it_wrong( __METHOD__, 'YARPP_Cache_Bypass::related cannot do a reverse lookup', '3.4' );
+            _doing_it_wrong( __METHOD__, 'JARPP_Cache_Bypass::related cannot do a reverse lookup', '3.4' );
             return;
         }
 

--- a/classes/JARPP_Cache_Postmeta.php
+++ b/classes/JARPP_Cache_Postmeta.php
@@ -1,6 +1,6 @@
 <?php
 
-class YARPP_Cache_Postmeta extends YARPP_Cache {
+class JARPP_Cache_Postmeta extends JARPP_Cache {
 
 	public $name = "postmeta";
 

--- a/classes/JARPP_Cache_Tables.php
+++ b/classes/JARPP_Cache_Tables.php
@@ -1,6 +1,6 @@
 <?php
 
-class YARPP_Cache_Tables extends YARPP_Cache {
+class JARPP_Cache_Tables extends JARPP_Cache {
 	public $name = "custom tables";
 
 	/**

--- a/classes/JARPP_Core.php
+++ b/classes/JARPP_Core.php
@@ -35,9 +35,9 @@ class YARPP {
 		load_plugin_textdomain('yarpp', false, plugin_basename(YARPP_DIR).'/lang');
 
 		/* Load cache object. */
-		$this->storage_class    = 'YARPP_Cache_'.ucfirst(YARPP_CACHE_TYPE);
+		$this->storage_class    = 'JARPP_Cache_'.ucfirst(YARPP_CACHE_TYPE);
 		$this->cache            = new $this->storage_class($this);
-		$this->cache_bypass     = new YARPP_Cache_Bypass($this);
+		$this->cache_bypass     = new JARPP_Cache_Bypass($this);
 
 		register_activation_hook(__FILE__, array($this, 'activate'));
 
@@ -77,8 +77,8 @@ class YARPP {
 		 * @since 3.4 Only load UI if we're in the admin.
          */
 		if (is_admin()) {
-			require_once(YARPP_DIR.'/classes/YARPP_Admin.php');
-			$this->admin = new YARPP_Admin($this);
+			require_once(YARPP_DIR.'/classes/JARPP_Admin.php');
+			$this->admin = new JARPP_Admin($this);
 			$this->enforce();
 		}
 	}

--- a/classes/JARPP_Meta_Box.php
+++ b/classes/JARPP_Meta_Box.php
@@ -1,6 +1,6 @@
 <?php
 
-class YARPP_Meta_Box {
+class JARPP_Meta_Box {
     protected $template_text = null;
     protected $yarpp         = null;
 

--- a/classes/JARPP_Meta_Box_Contact.php
+++ b/classes/JARPP_Meta_Box_Contact.php
@@ -1,6 +1,6 @@
 <?php
 
-class YARPP_Meta_Box_Contact extends YARPP_Meta_Box {
+class JARPP_Meta_Box_Contact extends JARPP_Meta_Box {
     public function display() {
 		global $yarpp;
 

--- a/classes/JARPP_Meta_Box_Display_Feed.php
+++ b/classes/JARPP_Meta_Box_Display_Feed.php
@@ -1,6 +1,6 @@
 <?php
 
-class YARPP_Meta_Box_Display_Feed extends YARPP_Meta_Box {
+class JARPP_Meta_Box_Display_Feed extends JARPP_Meta_Box {
     public function display() {
         global $yarpp;
 

--- a/classes/JARPP_Meta_Box_Display_Web.php
+++ b/classes/JARPP_Meta_Box_Display_Web.php
@@ -1,6 +1,6 @@
 <?php
 
-class YARPP_Meta_Box_Display_Web extends YARPP_Meta_Box {
+class JARPP_Meta_Box_Display_Web extends JARPP_Meta_Box {
     public function display() {
         global $yarpp;
 

--- a/classes/JARPP_Meta_Box_Pool.php
+++ b/classes/JARPP_Meta_Box_Pool.php
@@ -1,6 +1,6 @@
 <?php
 
-class YARPP_Meta_Box_Pool extends YARPP_Meta_Box {
+class JARPP_Meta_Box_Pool extends JARPP_Meta_Box {
 	public function exclude($taxonomy, $string) {
 		global $yarpp;
 

--- a/classes/JARPP_Meta_Box_Relatedness.php
+++ b/classes/JARPP_Meta_Box_Relatedness.php
@@ -1,6 +1,6 @@
 <?php
 
-class YARPP_Meta_Box_Relatedness extends YARPP_Meta_Box {
+class JARPP_Meta_Box_Relatedness extends JARPP_Meta_Box {
     public function display() {
         global $yarpp;
         ?>

--- a/classes/JARPP_Widget.php
+++ b/classes/JARPP_Widget.php
@@ -3,7 +3,7 @@
  * Vaguely based on code by MK Safi
  * http://msafi.com/fix-yet-another-related-posts-plugin-yarpp-widget-and-add-it-to-the-sidebar/
  */
-class YARPP_Widget extends WP_Widget {
+class JARPP_Widget extends WP_Widget {
 
 	public function __construct() {
 		parent::WP_Widget(false, 'Related Posts (YARPP)', array('description' => 'Related Posts and/or Sponsored Content'));
@@ -94,7 +94,7 @@ class YARPP_Widget extends WP_Widget {
  * @since 2.0 Add as a widget
  */
 function yarpp_widget_init() {
-    register_widget('YARPP_Widget');
+    register_widget('JARPP_Widget');
 }
 
 add_action('widgets_init', 'yarpp_widget_init');

--- a/includes/yarpp_meta_boxes_hooks.php
+++ b/includes/yarpp_meta_boxes_hooks.php
@@ -1,17 +1,17 @@
 <?php
-include_once(YARPP_DIR.'/classes/YARPP_Meta_Box.php');
-include_once(YARPP_DIR.'/classes/YARPP_Meta_Box_Contact.php');
-include_once(YARPP_DIR.'/classes/YARPP_Meta_Box_Display_Feed.php');
-include_once(YARPP_DIR.'/classes/YARPP_Meta_Box_Display_Web.php');
-include_once(YARPP_DIR.'/classes/YARPP_Meta_Box_Pool.php');
-include_once(YARPP_DIR.'/classes/YARPP_Meta_Box_Relatedness.php');
+include_once(YARPP_DIR.'/classes/JARPP_Meta_Box.php');
+include_once(YARPP_DIR.'/classes/JARPP_Meta_Box_Contact.php');
+include_once(YARPP_DIR.'/classes/JARPP_Meta_Box_Display_Feed.php');
+include_once(YARPP_DIR.'/classes/JARPP_Meta_Box_Display_Web.php');
+include_once(YARPP_DIR.'/classes/JARPP_Meta_Box_Pool.php');
+include_once(YARPP_DIR.'/classes/JARPP_Meta_Box_Relatedness.php');
 
 global $yarpp;
 
 add_meta_box(
     'yarpp_pool',
     __( '"The Pool"', 'yarpp' ),
-    array(new YARPP_Meta_Box_Pool, 'display'),
+    array(new JARPP_Meta_Box_Pool, 'display'),
     'settings_page_yarpp',
     'normal',
     'core'
@@ -21,7 +21,7 @@ add_meta_box(
     'yarpp_relatedness',
     __( '"Relatedness" options', 'yarpp' ),
     array(
-        new YARPP_Meta_Box_Relatedness,
+        new JARPP_Meta_Box_Relatedness,
         'display'
     ),
     'settings_page_yarpp',
@@ -33,7 +33,7 @@ add_meta_box(
     'yarpp_display_web',
     __('Display options <small>for your website</small>', 'yarpp'),
     array(
-        new YARPP_Meta_Box_Display_Web,
+        new JARPP_Meta_Box_Display_Web,
         'display'
     ),
     'settings_page_yarpp',
@@ -45,7 +45,7 @@ add_meta_box(
     'yarpp_display_rss',
     __('Display options <small>for RSS</small>', 'yarpp'),
     array(
-        new YARPP_Meta_Box_Display_Feed,
+        new JARPP_Meta_Box_Display_Feed,
         'display'
     ),
     'settings_page_yarpp',
@@ -56,7 +56,7 @@ add_meta_box(
 add_meta_box(
     'yarpp_display_contact',
     __('Contact YARPP', 'yarpp'),
-    array(new YARPP_Meta_Box_Contact, 'display'),
+    array(new JARPP_Meta_Box_Contact, 'display'),
     'settings_page_yarpp',
     'side',
     'core'

--- a/jarpp.php
+++ b/jarpp.php
@@ -51,11 +51,11 @@ include_once(YARPP_DIR.'/includes/init_functions.php');
 include_once(YARPP_DIR.'/includes/related_functions.php');
 include_once(YARPP_DIR.'/includes/template_functions.php');
 
-include_once(YARPP_DIR.'/classes/YARPP_Core.php');
-include_once(YARPP_DIR.'/classes/YARPP_Widget.php');
-include_once(YARPP_DIR.'/classes/YARPP_Cache.php');
-include_once(YARPP_DIR.'/classes/YARPP_Cache_Bypass.php');
-include_once(YARPP_DIR.'/classes/YARPP_Cache_'.ucfirst(YARPP_CACHE_TYPE).'.php');
+include_once(YARPP_DIR.'/classes/JARPP_Core.php');
+include_once(YARPP_DIR.'/classes/JARPP_Widget.php');
+include_once(YARPP_DIR.'/classes/JARPP_Cache.php');
+include_once(YARPP_DIR.'/classes/JARPP_Cache_Bypass.php');
+include_once(YARPP_DIR.'/classes/JARPP_Cache_'.ucfirst(YARPP_CACHE_TYPE).'.php');
 
 /* WP hooks ----------------------------------------------------------------------------------------------------------*/
 add_action('init', 'yarpp_init');


### PR DESCRIPTION
In order to get back on WordPress.org, Mika Epstein requested the classes be renamed from YARPP. I pointed out thought that I'd like to maintain backward compatibility, especially with the global `$yarpp`.

So I'll try to rename as much as possible, but some things can't be renamed without breaking 3rd party integrations, like hooks, globals, and maybe constants.

Todo:

* [ ] remove yarpp from other php files
* [ ] change images
* [ ] change copy

Can't Rename:

* option, table, and postmeta tables
* dynamic templates
* CSS classes